### PR TITLE
ci: GitHub Actions pipeline (test, GHCR build, Dokploy deploy)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.git/
+.github/
+.env
+.env.*
+.settings/
+.classpath
+.project
+.factorypath
+bruno/
+*.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,86 @@
+name: CI/CD
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE: ghcr.io/protosg/restaurant-management-backend
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+      - name: Run unit + integration tests (Testcontainers)
+        run: |
+          chmod +x mvnw
+          ./mvnw -B verify
+
+  build-push:
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Scan image (Trivy)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE }}:${{ github.sha }}
+          format: table
+          exit-code: '1'
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+  deploy:
+    needs: build-push
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Dokploy redeploy over SSH
+        uses: appleboy/ssh-action@v1
+        env:
+          DOKPLOY_TOKEN: ${{ secrets.DOKPLOY_TOKEN }}
+          DOKPLOY_APP_ID: ${{ secrets.DOKPLOY_APP_ID }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_KEY }}
+          envs: DOKPLOY_TOKEN,DOKPLOY_APP_ID
+          script: |
+            curl -fsS -X POST http://localhost:3000/api/application.deploy \
+              -H "x-api-key: $DOKPLOY_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "{\"applicationId\":\"$DOKPLOY_APP_ID\"}"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -56,7 +56,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Scan image (Trivy)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ env.IMAGE }}:${{ github.sha }}
           format: table


### PR DESCRIPTION
## Resumen
Pipeline CI/CD con GitHub Actions.

- **PR**: tests unitarios + integración (Testcontainers).
- **push a main**: build imagen Docker → push a GHCR (`:latest` + `:sha`) → scan Trivy (bloquea CRITICAL/HIGH) → deploy vía SSH que dispara redeploy en Dokploy.
- Dependabot (maven + github-actions).
- `.dockerignore` para no filtrar secretos/basura a la imagen.

## Requiere secrets en el repo
`SSH_HOST`, `SSH_USER`, `SSH_KEY`, `DOKPLOY_TOKEN`, `DOKPLOY_APP_ID`.

> Primer deploy: la imagen aún no existe en GHCR hasta el primer push a main.