### PR TITLE
fix(security): bump Spring Boot 3.5.14 + scan before push

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,14 +45,14 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and push image
+      # Construir local (load) → escanear → pushear solo si el scan pasa.
+      # Así una imagen con CVEs CRITICAL/HIGH nunca llega a GHCR.
+      - name: Build image (local)
         uses: docker/build-push-action@v7
         with:
           context: .
-          push: true
-          tags: |
-            ${{ env.IMAGE }}:latest
-            ${{ env.IMAGE }}:${{ github.sha }}
+          load: true
+          tags: ${{ env.IMAGE }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Scan image (Trivy)
@@ -63,6 +63,11 @@ jobs:
           exit-code: '1'
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+      - name: Push image (only if scan passed)
+        run: |
+          docker tag ${{ env.IMAGE }}:${{ github.sha }} ${{ env.IMAGE }}:latest
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest
 
   deploy:
     needs: build-push

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.6</version>
+		<version>3.5.14</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.restaurant-management</groupId>


### PR DESCRIPTION
## Por qué
Trivy marcó CVEs CRITICAL/HIGH en la imagen del backend:
- Spring Boot 3.5.6 → CVE-2026-40973 (fix 3.5.14)
- Spring Security 6.5.5 → CVE-2026-22732 CRITICAL (fix 6.5.9, vía boot 3.5.14)

## Cambios
- `pom.xml`: parent Spring Boot `3.5.6 → 3.5.14`.
- `ci-cd.yml`: build local → Trivy → push **solo si pasa** (antes pusheaba antes de escanear, dejando imagen vulnerable en GHCR).