### PR TITLE
chore(deps): group Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,19 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      # minor + patch juntos en un solo PR; los major quedan sueltos para revisarlos uno a uno
+      maven-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Agrupa minor+patch de Maven en un solo PR y todas las github-actions en otro; los major siguen sueltos para revisarlos uno a uno. Reduce el ruido de PRs.