### PR TITLE
fix(security): patch transitive CVEs (tomcat/jackson/postgresql)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,11 @@
 	</scm>
 	<properties>
 		<java.version>21</java.version>
+		<!-- Overrides de seguridad sobre el BOM de Spring Boot 3.5.14 (CVEs transitivos).
+		     Patches dentro del mismo minor; quitar cuando Boot suba a estas versiones. -->
+		<tomcat.version>10.1.55</tomcat.version>
+		<jackson-bom.version>2.21.4</jackson-bom.version>
+		<postgresql.version>42.7.11</postgresql.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Trivy marcó CVEs CRITICAL/HIGH en deps transitivas del BOM de Spring Boot 3.5.14:
- tomcat-embed-core 10.1.54 → CRITICAL (auth bypass) → 10.1.55
- jackson-databind 2.21.2 → HIGH (RCE) → 2.21.4
- postgresql 42.7.10 → HIGH (DoS) → 42.7.11

Override de versiones en `pom.xml` (patches, mismo minor). Quitar cuando Spring Boot suba a estas versiones.