### PR TITLE
fix(security): patch base image OS packages (p11-kit)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /app
 
+# Parchar paquetes del SO de la base (p.ej. p11-kit) a la última versión de Alpine
+RUN apk upgrade --no-cache
+
 # Usuario no-root por seguridad
 RUN addgroup -S -g 1001 spring && adduser -S -u 1001 -G spring spring
 


### PR DESCRIPTION
Trivy marcó 2 HIGH en p11-kit del Alpine base (temurin:21-jre-alpine). `apk upgrade --no-cache` en runtime sube a p11-kit 0.26.2-r0 (parcheado). Verificado: app deps ya en CRITICAL 0 tras el override transitivo.