### PR TITLE
ci: Docker Hub auth (kill rate-limit flakes)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,6 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Login a Docker Hub: Testcontainers baja postgres de docker.io; autenticado evita el rate-limit anónimo.
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: actions/setup-java@v5
         with:
           distribution: temurin
@@ -38,6 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # Login a Docker Hub antes de buildx (baja buildkit) y del build (imágenes base) → sin rate-limit.
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - uses: docker/setup-buildx-action@v3
       - name: Login to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
Login a Docker Hub en el job test (Testcontainers baja postgres) y en build-push (buildx baja buildkit). Evita los timeouts/rate-limit anonimos de registry-1.docker.io. Secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN.