### PR TITLE
feat(orders): quick-notes, auto-ready on print, RBAC hardening

### DIFF
--- a/src/main/java/com/restaurant_management/restaurant_management_backend/orders/OrderServiceImpl.java
+++ b/src/main/java/com/restaurant_management/restaurant_management_backend/orders/OrderServiceImpl.java
@@ -211,7 +211,19 @@ public class OrderServiceImpl implements OrderService {
       item.setKitchenPrintedQuantity(updated);
     }
 
+    // Enviar la comanda a cocina equivale a "listo": al no usar pantalla de
+    // cocina, la ticketera es la señal. Auto-transiciona IN_PROGRESS -> READY.
+    boolean markedReady = order.getStatus() == OrderStatus.IN_PROGRESS;
+    if (markedReady) {
+      order.markAsReady();
+    }
+
     orderRepository.save(order);
+
+    if (markedReady) {
+      Long tableId = order.getTable() != null ? order.getTable().getId() : null;
+      orderEventPublisher.publish(OrderEvent.Type.READY, order.getId(), tableId);
+    }
   }
 
   @Override
@@ -258,8 +270,8 @@ public class OrderServiceImpl implements OrderService {
     Order order = orderRepository.findByIdWithDetails(orderId)
         .orElseThrow(() -> new ResourceNotFoundException("Pedido no encontrado"));
 
-    if (order.getStatus() != OrderStatus.CREATED && order.getStatus() != OrderStatus.READY
-        && order.getStatus() != OrderStatus.PARTIALLY_PAID) {
+    if (order.getStatus() != OrderStatus.CREATED && order.getStatus() != OrderStatus.IN_PROGRESS
+        && order.getStatus() != OrderStatus.READY && order.getStatus() != OrderStatus.PARTIALLY_PAID) {
       throw new IllegalStateException("La orden no puede recibir pagos en este estado: " + order.getStatus());
     }
 

--- a/src/main/java/com/restaurant_management/restaurant_management_backend/orders/entity/Order.java
+++ b/src/main/java/com/restaurant_management/restaurant_management_backend/orders/entity/Order.java
@@ -128,8 +128,8 @@ public class Order extends AuditableEntity {
   }
 
   public void markAsPaid() {
-    if (this.status != OrderStatus.CREATED && this.status != OrderStatus.READY
-        && this.status != OrderStatus.PARTIALLY_PAID) {
+    if (this.status != OrderStatus.CREATED && this.status != OrderStatus.IN_PROGRESS
+        && this.status != OrderStatus.READY && this.status != OrderStatus.PARTIALLY_PAID) {
       throw new IllegalStateException("Order no puede ser pagado en este estado: " + this.status);
     }
     this.status = OrderStatus.PAID;

--- a/src/main/java/com/restaurant_management/restaurant_management_backend/shared/config/SystemConfig.java
+++ b/src/main/java/com/restaurant_management/restaurant_management_backend/shared/config/SystemConfig.java
@@ -22,6 +22,6 @@ public class SystemConfig extends AuditableEntity {
   @Column(name = "config_key", length = 100)
   private String key;
 
-  @Column(name = "config_value", nullable = false, length = 255)
+  @Column(name = "config_value", nullable = false, columnDefinition = "TEXT")
   private String value;
 }

--- a/src/main/java/com/restaurant_management/restaurant_management_backend/shared/config/SystemConfigController.java
+++ b/src/main/java/com/restaurant_management/restaurant_management_backend/shared/config/SystemConfigController.java
@@ -38,4 +38,14 @@ public class SystemConfigController {
   public ResponseEntity<List<Long>> updateQuickAddProducts(@RequestBody List<Long> ids) {
     return ResponseEntity.ok(systemConfigService.updateQuickAddProducts(ids));
   }
+
+  @GetMapping("/quick-notes")
+  public ResponseEntity<List<String>> getQuickNotes() {
+    return ResponseEntity.ok(systemConfigService.getQuickNotes());
+  }
+
+  @PutMapping("/quick-notes")
+  public ResponseEntity<List<String>> updateQuickNotes(@RequestBody List<String> notes) {
+    return ResponseEntity.ok(systemConfigService.updateQuickNotes(notes));
+  }
 }

--- a/src/main/java/com/restaurant_management/restaurant_management_backend/shared/config/SystemConfigService.java
+++ b/src/main/java/com/restaurant_management/restaurant_management_backend/shared/config/SystemConfigService.java
@@ -23,6 +23,7 @@ public class SystemConfigService {
 
   private static final String TAKEAWAY_SURCHARGE_KEY = "takeaway_surcharge";
   private static final String QUICK_ADD_KEY = "quick_add_product_ids";
+  private static final String QUICK_NOTES_KEY = "quick_note_suggestions";
 
   private final SystemConfigRepository systemConfigRepository;
   private final ObjectMapper objectMapper;
@@ -69,5 +70,33 @@ public class SystemConfigService {
     }
     systemConfigRepository.save(config);
     return ids;
+  }
+
+  @Transactional(readOnly = true)
+  public List<String> getQuickNotes() {
+    return systemConfigRepository.findById(QUICK_NOTES_KEY)
+        .map(c -> {
+          try {
+            return objectMapper.readValue(c.getValue(), new TypeReference<List<String>>() {});
+          } catch (JsonProcessingException e) {
+            log.warn("Valor inválido en config '{}': {}. Devolviendo lista vacía.", QUICK_NOTES_KEY, e.getMessage());
+            return Collections.<String>emptyList();
+          }
+        })
+        .orElseGet(Collections::emptyList);
+  }
+
+  @Transactional
+  public List<String> updateQuickNotes(List<String> notes) {
+    SystemConfig config = systemConfigRepository.findById(QUICK_NOTES_KEY)
+        .orElse(new SystemConfig(QUICK_NOTES_KEY, "[]"));
+    try {
+      config.setValue(objectMapper.writeValueAsString(notes));
+    } catch (JsonProcessingException e) {
+      log.error("No se pudo serializar quick-notes: {}", e.getMessage());
+      throw new IllegalArgumentException("Lista de notas inválida", e);
+    }
+    systemConfigRepository.save(config);
+    return notes;
   }
 }

--- a/src/main/java/com/restaurant_management/restaurant_management_backend/shared/security/SecurityConfig.java
+++ b/src/main/java/com/restaurant_management/restaurant_management_backend/shared/security/SecurityConfig.java
@@ -50,10 +50,16 @@ public class SecurityConfig {
         .requestMatchers(HttpMethod.POST, "/orders/*/ready").hasAnyRole("ADMIN", "CHEF")
         // Analytics — ADMIN or CASHIER
         .requestMatchers("/analytics/**").hasAnyRole("ADMIN", "CASHIER")
+        // Quick notes — readable by any authenticated staff (waiters take orders)
+        .requestMatchers(HttpMethod.GET, "/config/quick-notes").authenticated()
         // System config — ADMIN only
         .requestMatchers("/config/**").hasRole("ADMIN")
         // User management — ADMIN only
         .requestMatchers("/users/**").hasRole("ADMIN")
+        // Table write operations — ADMIN only
+        .requestMatchers(HttpMethod.POST, "/tables/**").hasRole("ADMIN")
+        .requestMatchers(HttpMethod.PUT, "/tables/**").hasRole("ADMIN")
+        .requestMatchers(HttpMethod.DELETE, "/tables/**").hasRole("ADMIN")
         // Menu write operations — ADMIN only
         .requestMatchers(HttpMethod.POST, "/categories/**", "/products/**").hasRole("ADMIN")
         .requestMatchers(HttpMethod.PUT, "/categories/**", "/products/**").hasRole("ADMIN")

--- a/src/main/resources/db/migration/V17__widen_system_config_value.sql
+++ b/src/main/resources/db/migration/V17__widen_system_config_value.sql
@@ -1,0 +1,1 @@
+ALTER TABLE system_config ALTER COLUMN config_value TYPE TEXT;


### PR DESCRIPTION
## Cambios

- **Quick-notes**: `GET/PUT /config/quick-notes` para sugerencias de notas de orden reutilizables (lectura por cualquier staff autenticado, edición solo ADMIN).
- **DB**: `system_config.config_value` ampliado a `TEXT` (migración `V17`) para almacenar listas de notas.
- **Auto-ready**: al imprimir la comanda en cocina la orden pasa `IN_PROGRESS -> READY` y publica `OrderEvent(READY)` (la ticketera es la señal de listo, sin KDS).
- **Pagos**: se permiten con la orden en `IN_PROGRESS`.
- **RBAC**: escritura de mesas (`POST/PUT/DELETE /tables`) restringida a ADMIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)